### PR TITLE
Add red color scheme to CSS styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@ body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     line-height: 1.6;
     color: #333;
-    background-color: #f8f9fa;
+    background-color: #fef5f5;
 }
 
 .container {
@@ -20,14 +20,14 @@ body {
 
 /* Header and Navigation */
 header {
-    background-color: #2c3e50;
+    background-color: #b91c1c;
     color: white;
     padding: 1rem 0;
     position: fixed;
     width: 100%;
     top: 0;
     z-index: 1000;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 5px rgba(185, 28, 28, 0.3);
 }
 
 .nav-container {
@@ -57,12 +57,12 @@ header {
 }
 
 .nav-menu a:hover {
-    color: #3498db;
+    color: #fca5a5;
 }
 
 /* Hero Section */
 .hero {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
     color: white;
     padding: 150px 0 100px;
     text-align: center;
@@ -82,7 +82,7 @@ header {
 }
 
 .cta-button {
-    background-color: #3498db;
+    background-color: #ef4444;
     color: white;
     padding: 12px 30px;
     border: none;
@@ -93,7 +93,7 @@ header {
 }
 
 .cta-button:hover {
-    background-color: #2980b9;
+    background-color: #dc2626;
 }
 
 /* About Section */
@@ -106,7 +106,7 @@ header {
     font-size: 2.5rem;
     margin-bottom: 2rem;
     text-align: center;
-    color: #2c3e50;
+    color: #b91c1c;
 }
 
 .about p {
@@ -126,7 +126,7 @@ header {
     font-size: 1.8rem;
     margin-bottom: 1rem;
     text-align: center;
-    color: #2c3e50;
+    color: #b91c1c;
 }
 
 .skill-tags {
@@ -138,7 +138,7 @@ header {
 }
 
 .skill-tag {
-    background-color: #3498db;
+    background-color: #ef4444;
     color: white;
     padding: 8px 16px;
     border-radius: 20px;
@@ -149,14 +149,14 @@ header {
 /* Projects Section */
 .projects {
     padding: 80px 0;
-    background-color: #f8f9fa;
+    background-color: #fef2f2;
 }
 
 .projects h2 {
     font-size: 2.5rem;
     margin-bottom: 3rem;
     text-align: center;
-    color: #2c3e50;
+    color: #b91c1c;
 }
 
 .project-grid {
@@ -170,19 +170,20 @@ header {
     background-color: white;
     padding: 2rem;
     border-radius: 10px;
-    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    box-shadow: 0 5px 15px rgba(185, 28, 28, 0.1);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border-left: 4px solid #ef4444;
 }
 
 .project-card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 10px 25px rgba(0,0,0,0.15);
+    box-shadow: 0 10px 25px rgba(185, 28, 28, 0.15);
 }
 
 .project-card h3 {
     font-size: 1.5rem;
     margin-bottom: 1rem;
-    color: #2c3e50;
+    color: #b91c1c;
 }
 
 .project-card p {
@@ -191,14 +192,14 @@ header {
 }
 
 .project-link {
-    color: #3498db;
+    color: #ef4444;
     text-decoration: none;
     font-weight: 600;
     transition: color 0.3s ease;
 }
 
 .project-link:hover {
-    color: #2980b9;
+    color: #dc2626;
 }
 
 /* Contact Section */
@@ -211,7 +212,7 @@ header {
 .contact h2 {
     font-size: 2.5rem;
     margin-bottom: 1rem;
-    color: #2c3e50;
+    color: #b91c1c;
 }
 
 .contact p {
@@ -231,7 +232,7 @@ header {
 
 /* Footer */
 footer {
-    background-color: #2c3e50;
+    background-color: #b91c1c;
     color: white;
     text-align: center;
     padding: 2rem 0;


### PR DESCRIPTION
This pull request updates the CSS styling with a red color scheme. 

## Changes Made:
- Updated header background to deep red (#b91c1c)
- Changed hero section gradient to red tones (#dc2626 to #991b1b)
- Modified all headings to use red colors (#b91c1c)
- Updated button colors to red variants (#ef4444)
- Changed skill tags to red background
- Added red accent borders to project cards
- Updated navigation hover effects to use light red
- Changed body background to a subtle red tint (#fef5f5)
- Modified project section background to light red (#fef2f2)
- Updated footer to match the red theme

The design maintains readability while incorporating various shades of red throughout the interface for a cohesive color scheme.